### PR TITLE
Fix schemars crate version to that in upstream bevy_impulse crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bevy_app = "0.12"
 bevy_core = "0.12"
 bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main", features = ["diagram"] }
 serde = "*"
-schemars = "*"
+schemars = "0.9.0"
 serde_json = "*"
 tokio = { version = "1.39", features = ["sync"] }
 clap = { version = "*", features = ["derive"] }


### PR DESCRIPTION

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discourse [discussions page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-general/103) or [proposals page](https://discourse.openrobotics.org/c/open-rmf/open-rmf-ideas/105).
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

Addresses issue #1

### Fix applied

Fix `colcon build` error by fixing schemars crate version to that in upstream bevy_impulse crate


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
